### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - '0.10'
-  - '0.12'
-  - '4'
-  - '6'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+/** Determines whether an object has a property with the specified name. */
+export default function hasOwnProperty (object: object, name: string | number | symbol): boolean

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-var _hasOwnProperty = Object.prototype.hasOwnProperty
+const _hasOwnProperty = Object.prototype.hasOwnProperty
 
-module.exports = function hasOwnProperty (obj, prop) {
-  return _hasOwnProperty.call(obj, prop)
+export default function hasOwnProperty (object, name) {
+  return _hasOwnProperty.call(object, name)
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
   "version": "1.0.0",
   "license": "MIT",
   "repository": "LinusU/has-own-property",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "devDependencies": {
-    "standard": "^7.1.1"
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.3"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,20 @@ npm install --save has-own-property
 ## Usage
 
 ```js
-const hasOwnProperty = require('has-own-property')
+import hasOwnProperty from 'has-own-property'
 
 const obj = { a: 1 }
 
 hasOwnProperty(obj, 'a') // true
 hasOwnProperty(obj, 'b') // false
 ```
+
+## API
+
+### `hasOwnProperty(object, name)`
+
+- `object` (`object`, required)
+- `name` (`string | number | symbol`, required)
+- returns `boolean`
+
+Determines whether an object has a property with the specified name.

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
-var assert = require('assert')
-var hasOwnProperty = require('./')
+import assert from 'node:assert'
+import hasOwnProperty from './index.js'
 
-var obj = { a: 1, c: 2 }
+const obj = { a: 1, c: 2 }
 
-assert.equal(hasOwnProperty(obj, 'a'), true)
-assert.equal(hasOwnProperty(obj, 'b'), false)
-assert.equal(hasOwnProperty(obj, 'c'), true)
+assert.strictEqual(hasOwnProperty(obj, 'a'), true)
+assert.strictEqual(hasOwnProperty(obj, 'b'), false)
+assert.strictEqual(hasOwnProperty(obj, 'c'), true)
 
-assert.equal(hasOwnProperty(obj, 'toString'), false)
-assert.equal(hasOwnProperty(obj, 'valueOf'), false)
+assert.strictEqual(hasOwnProperty(obj, 'toString'), false)
+assert.strictEqual(hasOwnProperty(obj, 'valueOf'), false)


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`